### PR TITLE
Changed translation for install selection.

### DIFF
--- a/welcome/translations-welcome-fr.bash
+++ b/welcome/translations-welcome-fr.bash
@@ -161,8 +161,8 @@ _tr_add2 issues_no               "Aucun problème important n'a été détecté 
 _tr_add2 cal_noavail             "Non disponible : "        # programme d'installation
 _tr_add2 cal_warn                "Avertissement"
 _tr_add2 cal_info1               "C'est une version de développement communautaire.\n\n"		# besoins spéciaux !
-_tr_add2 cal_info2               "<b>Horsligne</b> ce mode vous donne un bureau Xfce avec le thème EndeavourOS.\nUne connexion Internet n'est pas nécessaire.\n\n"
-_tr_add2 cal_info3               "<b>Enligne</b> ce mode vous laisse choisir votre bureau, avec le thème d'origine (vanilla).\nUne connexion Internet est requise.\n\n"
+_tr_add2 cal_info2               "<b>Offline</b> ce mode vous donne un bureau Xfce avec le thème EndeavourOS.\nUne connexion Internet n'est pas nécessaire.\n\n"
+_tr_add2 cal_info3               "<b>Online</b> ce mode vous laisse choisir votre bureau, avec le thème d'origine (vanilla).\nUne connexion Internet est requise.\n\n"
 _tr_add2 cal_info4               "Veuillez noter : Cette version est un travail en cours, veuillez nous aider à la rendre stable en signalant les bogues.\n"
 _tr_add2 cal_choose              "Choisir le mode d'installation"
 _tr_add2 cal_method              "Mode"


### PR DESCRIPTION
Hello.

I noticed that install option are not translated in installation dialog box. Keeping english is better here. See attached screenshot.

![VirtualBox_EndeavourOS - build_22_01_2020_12_26_44](https://user-images.githubusercontent.com/8571419/72890782-ff4a8180-3d12-11ea-90fd-fdf415ff0a1a.png)
