### PR TITLE
i3 support of `eos-set-background-picture`

### DIFF
--- a/welcome/eos-script-lib-yad
+++ b/welcome/eos-script-lib-yad
@@ -248,6 +248,9 @@ eos_yad__detectDE()
          X-Generic)
            DE=generic
            ;;
+         i3)
+           DE=i3
+           ;;
       esac
     fi
 

--- a/welcome/eos-set-background-picture
+++ b/welcome/eos-set-background-picture
@@ -193,6 +193,10 @@ Main()
             AssertPicture ${picprefix}xfce4.png no && \
                 XfceSetWallpaper
             ;;
+        I3)
+            AssertPicture ${picprefix}i3.png no && \
+                feh --bg-scale "$pic"
+            ;;
         *)
             DIE "Sorry, desktop '$DE' is not supported."
             ;;


### PR DESCRIPTION
By default I3 has set up default wallpaper but in case you changed it and wanted get back through `welcome` or `eos-set-background-picture` it would not work out.

You'd get the following error.

```
Sorry, desktop '' is not supported.
```

It set up  a wallpaper via `feh` which is available by default but there might be any better options.

Recognizing i3 as a desktop environment may affect some other if branches.