### PR TITLE
Update eos-hooks-runner

### DIFF
--- a/eos-hooks/eos-hooks-runner
+++ b/eos-hooks/eos-hooks-runner
@@ -5,6 +5,7 @@
 Lsb_release() {
     sed -i /etc/lsb-release \
         -e 's|^DISTRIB_ID=.*$|DISTRIB_ID=EndeavourOS|' \
+        -e 's|^DISTRIB_CODENAME=.*$|DISTRIB_CODENAME=rolling|' \
         -e 's|^DISTRIB_DESCRIPTION=.*$|DISTRIB_DESCRIPTION=\"EndeavourOS Linux\"|'
 }
 


### PR DESCRIPTION
-e 's|^DISTRIB_CODENAME=.*$|DISTRIB_CODENAME=rolling|' \

https://forum.endeavouros.com/t/open-lsb-release-should-set-the-distro-codename/11854/2