### PR TITLE
Added grub-theme-endeavouros-classic and endeavouros-backgrounds-classic

### DIFF
--- a/endeavouros-backgrounds-classic/PKGBUILD
+++ b/endeavouros-backgrounds-classic/PKGBUILD
@@ -1,0 +1,28 @@
+# Original Source: https://github.com/endeavouros-team/PKGBUILDS/blob/master/endeavouros-theming/PKGBUILD
+# Maintainer: LeSnake04 (dev.lesnake@gmail.com)
+pkgname=endeavouros-backgrounds-classic
+pkgver=6.4.1
+pkgrel=1
+pkgdesc='old EndeavourOS background images'
+arch=('any')
+url='https://www.endeavouros.com'
+license=('GPL3')
+
+source=(
+  "${pkgname}-${pkgver}.tar.gz::https://github.com/lesnake04/${pkgname}/archive/${pkgver}.tar.gz"
+)
+md5sums=('d886608813ce619e6196a6ac6d902218')
+sha512sums=('0551391fb1cdf173806cf0ebf4502d34159404dbc195fc11c2cc3e20de459e4b2af8529b673475e3f564c844766d717806635914b2837c26b834d6e43b2a5cfa')
+install=$pkgname.install
+
+package() {
+  cd "$srcdir/${pkgname}-$pkgver"
+  install -d "${pkgdir}/usr/share/endeavouros/backgrounds/"
+
+  cd backgrounds
+  install -Dm644 *.png                 "${pkgdir}/usr/share/endeavouros/backgrounds/"
+
+  # cleanup
+  cd $srcdir
+  rm -f ../${pkgname}-${pkgver}.tar.gz
+}

--- a/endeavouros-backgrounds-classic/endeavouros-backgrounds-classic.install
+++ b/endeavouros-backgrounds-classic/endeavouros-backgrounds-classic.install
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+pre_upgrade() {
+    # Remove some files (possible leftovers from other packages).
+
+    local remove=(
+       /usr/share/endeavouros/backgrounds/endeavouros-wallpaper-classic.png
+       /usr/share/endeavouros/backgrounds/endeavouros_plasma-classic.png
+       /usr/share/endeavouros/backgrounds/endeavouros_openbox-classic.png
+       /usr/share/endeavouros/backgrounds/endeavouros_mate-classic.png
+       /usr/share/endeavouros/backgrounds/endeavouros_lxqt-classic.png
+       /usr/share/endeavouros/backgrounds/endeavouros_i3-classic.png
+       /usr/share/endeavouros/backgrounds/endeavouros_gnome-classic.png
+       /usr/share/endeavouros/backgrounds/endeavouros_deepin-classic.png
+       /usr/share/endeavouros/backgrounds/endeavouros_cinnamon-classic.png
+       /usr/share/endeavouros/backgrounds/endeavouros_budgie-classic.png
+       /usr/share/endeavouros/backgrounds/arm-endeavouros_xfce4-classic.png
+       /usr/share/endeavouros/backgrounds/arm-endeavouros-wallpaper-classic.png
+       /usr/share/endeavouros/backgrounds/arm-endeavouros_plasma-classic.png
+       /usr/share/endeavouros/backgrounds/arm-endeavouros_openbox-classic.png
+       /usr/share/endeavouros/backgrounds/arm-endeavouros_mate-classic.png
+       /usr/share/endeavouros/backgrounds/arm-endeavouros_lxqt-classic.png
+       /usr/share/endeavouros/backgrounds/arm-endeavouros_i3-classic.png
+       /usr/share/endeavouros/backgrounds/arm-endeavouros_gnome-classic.png
+       /usr/share/endeavouros/backgrounds/arm-endeavouros_deepin-classic.png
+       /usr/share/endeavouros/backgrounds/arm-endeavouros_cinnamon-classic.png
+       /usr/share/endeavouros/backgrounds/arm-endeavouros_budgie-classic.png
+    )
+    local xx removed=()
+
+    # Test if the files to be removed really exist.
+    for xx in "${remove[@]}" ; do
+        test -r $xx && removed+=($xx)
+    done
+
+    # Now remove the ones that exist.
+    if [ -n "$removed" ] ; then
+        echo "Removing existing files:" >&2
+        for xx in "${removed[@]}" ; do
+            echo "    $xx" >&2
+            rm -f $xx
+        done
+    fi
+}
+
+pre_install() {
+    pre_upgrade
+}

--- a/grub-theme-endeavouros-classic/PKGBUILD
+++ b/grub-theme-endeavouros-classic/PKGBUILD
@@ -1,0 +1,22 @@
+# Base Maintainer: Filipe Laíns (FFY00) <lains@archlinux.org>
+# Original Sources: https://github.com/Se7endAY/grub2-theme-vimix; https://github.com/endeavouros-team/grub2-theme-endeavouros
+# Maintainer: LeSnake04 (dev.lesnake@gmail.com)
+pkgname=grub2-theme-endeavouros-classic
+pkgver=20210226
+pkgrel=1
+pkgdesc='EndeavourOS grub2 theme'
+arch=(any)
+url='https://github.com/endeavouros-team/'
+license=('GPL3')
+depends=('grub')
+optdepends=('grub-customizer: GUI tool to configure grub')
+replaces=('vimix-grub' 'grub-theme-vimix' 'grub-themes-vimix')
+conflicts=('grub2-theme-endeavouros')
+makedepends=('git')
+source=('git+https://github.com/lesnake04/grub2-theme-endeavouros-classic')
+sha512sums=('SKIP')
+
+package() {
+    install -dm 755 $pkgdir/boot/grub/themes/EndeavourOS
+    cp -r --no-preserve=ownership grub2-theme-endeavouros-classic/EndeavourOS $pkgdir/boot/grub/themes/
+}


### PR DESCRIPTION
# PKGBUILDs for the old grub themes and backgrounds

## grub-theme-endeavouros-classic
Replaces grub-theme-endeavouros with the old theme

## endeavouros-backgrounds-classic
adds old backgrounds to  `/usr/share/endeavouros/backgrounds/`
I added a `-classic` to the backgrounds to avoid conflicts with endeavouros-theming