### PR TITLE
endeavouros-mirrorlist - enable backup again

### DIFF
--- a/endeavouros-mirrorlist/PKGBUILD
+++ b/endeavouros-mirrorlist/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname=endeavouros-mirrorlist
 pkgver=4.4
-pkgrel=1
+pkgrel=2
 pkgdesc="EndeavourOS mirrorlist"
 arch=('any')
 url=https://github.com/endeavouros-team/PKGBUILDS/tree/master/$pkgname

--- a/endeavouros-mirrorlist/PKGBUILD
+++ b/endeavouros-mirrorlist/PKGBUILD
@@ -10,7 +10,7 @@ _url="https://raw.githubusercontent.com/endeavouros-team/PKGBUILDS/master/$pkgna
 
 license=('GPL3')
 options=(!strip !emptydirs)
-#backup=("etc/pacman.d/$pkgname")  # to keep possibly ranked mirrorlist
+backup=("etc/pacman.d/$pkgname")  # to keep possibly ranked mirrorlist
 
 conflicts_aarch64=(endeavouros-arm-mirrorlist)
 conflicts_armv7h=(endeavouros-arm-mirrorlist)


### PR DESCRIPTION
Hi,

backup line should not be disabled:

1. Users that have manually customized the list and do not use the auto-ranking functionality will suffer since it will always overwrite their list.
2. Backup functionality in eos-rankmirrors will not work as desired when triggered from the hook because it will backup the "default list" that just came in with this package rather the users version before.