### PR TITLE
Update Bspwm CE Pkgrel

### DIFF
--- a/eos-skel-ce-bspwm/PKGBUILD
+++ b/eos-skel-ce-bspwm/PKGBUILD
@@ -5,7 +5,7 @@
 _pkgname=bspwm
 pkgname=eos-skel-ce-bspwm
 pkgver=1.0
-pkgrel=9
+pkgrel=10
 pkgdesc="Pre user creation skel setup for Bspwm EOS-CE"
 arch=('any')
 groups=('eos-ce')


### PR DESCRIPTION
Bspwm CE now has picom disabled by default.