### PR TITLE
Update eos-skel-ce-worm PKGBUILD to the next pkgrel

### DIFF
--- a/eos-skel-ce-worm/PKGBUILD
+++ b/eos-skel-ce-worm/PKGBUILD
@@ -19,7 +19,8 @@ package() {
     cd "$_pkgname"
     mkdir -p "${pkgdir}${PREFIX}/.config/"
     chmod +x .config/worm/rc
-    chmod +x .config/sxhkd/sxhkdrc
+    chmod +x .config/sxhkd/sxhkdrc          
     install -Dm644 ".Xresources" "${pkgdir}${PREFIX}/.Xresources"
+    install -Dm644 ".dmrc" "${pkgdir}${PREFIX}/.dmrc"
     cp -R ".config/" "${pkgdir}${PREFIX}/"
 }

--- a/eos-skel-ce-worm/PKGBUILD
+++ b/eos-skel-ce-worm/PKGBUILD
@@ -4,7 +4,7 @@
 _pkgname=worm
 pkgname=eos-skel-ce-worm
 pkgver=1.0
-pkgrel=6
+pkgrel=7
 pkgdesc="pre user creation skel setup for worm EOS-CE"
 arch=('any')
 groups=('eos-ce')

--- a/eos-skel-ce-worm/PKGBUILD
+++ b/eos-skel-ce-worm/PKGBUILD
@@ -19,7 +19,7 @@ package() {
     cd "$_pkgname"
     mkdir -p "${pkgdir}${PREFIX}/.config/"
     chmod +x .config/worm/rc
-    chmod +x .config/sxhkd/sxhkdrc          
+    chmod +x .config/sxhkd/sxhkdrc
     install -Dm644 ".Xresources" "${pkgdir}${PREFIX}/.Xresources"
     install -Dm644 ".dmrc" "${pkgdir}${PREFIX}/.dmrc"
     cp -R ".config/" "${pkgdir}${PREFIX}/"


### PR DESCRIPTION
This force-triggers a rebuild to the latest git version. The dependency in one of the files needs to be changed from polybar to tint2 but I don't think that is this repository...