### PR TITLE
Update eos-install-mode-run-calamares

### DIFF
--- a/welcome/eos-install-mode-run-calamares
+++ b/welcome/eos-install-mode-run-calamares
@@ -80,7 +80,7 @@ EOF
 
 ### Starts calamares and runs it in the background. ###
 Calamares_Start() {
-    pkexec calamares -D6 -style kvantum >> $log &
+    pkexec calamares -style kvantum -D8 >> $log &
 }
 
 ### Dialog that asks for the online or offline edition. ###

--- a/welcome/eos-install-mode-run-calamares
+++ b/welcome/eos-install-mode-run-calamares
@@ -80,7 +80,7 @@ EOF
 
 ### Starts calamares and runs it in the background. ###
 Calamares_Start() {
-    pkexec calamares -style kvantum -c /etc/calamares/ -d >> $log &
+    pkexec calamares -D6 -style kvantum >> $log &
 }
 
 ### Dialog that asks for the online or offline edition. ###


### PR DESCRIPTION
option -d is now    "the developer mode flash"   as Adrian says so removed  pkexec calamares -style kvantum -c /etc/calamares/ -d >> $log &

and adding -D6 is the way to go ..

Not 100% sure about the change so check this please @manuel-192 @dalto8 @Portergos 