### PR TITLE
Update eos-install-mode-run-calamares

### DIFF
--- a/welcome/eos-install-mode-run-calamares
+++ b/welcome/eos-install-mode-run-calamares
@@ -55,7 +55,7 @@ InstallLog_Start() {
     local ISO_version=$(cat /usr/lib/endeavouros-release | cut -d'=' -f2)
     local calamares_version="$(pacman -Q calamares 2>/dev/null | awk '{print $NF}')"
 
-    [ -n "$calamares_version"] || calamares_version="$(pacman -Q calamares_current 2>/dev/null | awk '{print $NF}')"  # this line is probably not needed
+    [ -n "$calamares_version"] || calamares_version="$(pacman -Q calamares 2>/dev/null | awk '{print $NF}')"  # this line is probably not needed
 
     cat <<EOF > $log
 ########## $log by $progname


### PR DESCRIPTION
pacman -Q calamares 2>/dev/null | awk '{print $NF}'

it should work using calamares instead of calamares_current as packages providing as calamares .. 
https://github.com/endeavouros-team/PKGBUILDS/blob/ebf8081a9fa8613a03c9326f8f5ad70e5e56841c/calamares_current/PKGBUILD#L25
https://github.com/endeavouros-team/PKGBUILDS/blob/ebf8081a9fa8613a03c9326f8f5ad70e5e56841c/calamares-git/PKGBUILD#L25