### PR TITLE
modify calamares make command

### DIFF
--- a/calamares_current/PKGBUILD
+++ b/calamares_current/PKGBUILD
@@ -80,7 +80,7 @@ build() {
     plymouthcfg plasmalnf services-openrc \
     summaryq tracking usersq webview welcomeq"
     export DESTDIR="$srcdir/$_reponame/build/$pkgname"
-    make -j4 install
+    make install
 }
 
 package() {


### PR DESCRIPTION
Modify calamares_current PKGBUILD make command to be dependent on users makeflags instead of using -j4