### PR TITLE
Fix typo in eos-rankmirrors

### DIFF
--- a/eos-rankmirrors/README.md
+++ b/eos-rankmirrors/README.md
@@ -1,6 +1,6 @@
 # eos-rankmirrors
 
-`eos-rankmirrors` ranks the mirrors that provide the EndeaavourOS repository.<br>
+`eos-rankmirrors` ranks the mirrors that provide the EndeavourOS repository.<br>
 
 ## Synopsis
 ```


### PR DESCRIPTION
Changed "Ende**aa**vourOS" to "Ende**a**vourOS" (double a's)