### PR TITLE
Update PKGBUILD

### DIFF
--- a/eos-skel-ce-sway/PKGBUILD
+++ b/eos-skel-ce-sway/PKGBUILD
@@ -5,7 +5,7 @@
 _pkgname=sway
 pkgname=eos-skel-ce-sway
 pkgver=1.0
-pkgrel=11
+pkgrel=12
 pkgdesc="pre user creation skel setup for SWAY EOS-CE"
 arch=('any')
 url="https://github.com/EndeavourOS-Community-Editions/${_pkgname}"


### PR DESCRIPTION
Sway 1.8 changed "dpms" to "power" . Dpms will still work but it will be removed in a future version.

https://github.com/EndeavourOS-Community-Editions/sway/pull/45