### PR TITLE
I fixed the typos in the German translation

### DIFF
--- a/eos-translations/translation-de.bash
+++ b/eos-translations/translation-de.bash
@@ -328,7 +328,7 @@ _tr_add2 ins_custom_tip              "Möglichkeiten die Installation anzupassen
 
 
 # 2022-Jul-15
-_tr_add2 daily_assist_anews          "Archlinux Neugkeiten"
+_tr_add2 daily_assist_anews          "Archlinux Neuigkeiten"
 _tr_add2 daily_assist_anewstip       "Zeigt Neugkeiten über Archlinux im Browser an"
 
 

--- a/eos-translations/translation-de.bash
+++ b/eos-translations/translation-de.bash
@@ -328,8 +328,8 @@ _tr_add2 ins_custom_tip              "Möglichkeiten die Installation anzupassen
 
 
 # 2022-Jul-15
-_tr_add2 daily_assist_anews          "Archlinux Neuigkeiten"
-_tr_add2 daily_assist_anewstip       "Zeigt Neugkeiten über Archlinux im Browser an"
+_tr_add2 daily_assist_anews          "Arch Linux Neuigkeiten"
+_tr_add2 daily_assist_anewstip       "Zeigt Neugkeiten über Arch Linux im Browser an"
 
 
 # 2022-Sep-25


### PR DESCRIPTION
"Neugkeiten" to "Neuigkeiten"
"Archlinux" to "Arch Linux" - Source: https://archlinux.org/