### PR TITLE
[eos-update-notifier] Add UpdateInTerminal action

### DIFF
--- a/eos-bash-shared/eos-script-lib-yad
+++ b/eos-bash-shared/eos-script-lib-yad
@@ -166,6 +166,7 @@ eos_notification() {
     local appname="$4"
     local summary="$5"
     local body="$6"
+    local action="$7"
     [ -n "$urgency" ] || urgency=normal
 
     local cmd=(
@@ -173,7 +174,8 @@ eos_notification() {
         --icon="$icon"
         --urgency="$urgency"
         --expire-time="$expiretime"
-        --app-name="appname"
+        --app-name="$appname"
+        --action="$action"
         "$summary"
 	"$body"
     )

--- a/eos-update-notifier/eos-update-notifier
+++ b/eos-update-notifier/eos-update-notifier
@@ -85,15 +85,17 @@ ShowNotify() {
     esac
     if [ 0 -eq 1 ] ; then
         expiretime="--expire-time=$expiretime"
-        cmd=$(/usr/bin/notify-send --icon="$_UpdateNotifyIcon" --urgency=normal $expiretime \
-                             --app-name="EndeavourOS Update Notifier" \
-                             "Updates available ($progname)" \
-			     "$msg" --action "UpdateInTerminal --nt"=update)
-	bash -c "$cmd"
+        local cmd=$(/usr/bin/notify-send --icon="$_UpdateNotifyIcon" --urgency=normal $expiretime \
+                                         --app-name="EndeavourOS Update Notifier" \
+                                         "Updates available ($progname)" \
+            	      "$msg" --action="UpdateInTerminal --nt=update")
+        bash -c "$cmd"
     else
-        eos_notification "$_UpdateNotifyIcon" "normal" "$expiretime" "EndeavourOS Update Notifier" \
+        local cmd=$(eos_notification "$_UpdateNotifyIcon" "normal" "$expiretime" "EndeavourOS Update Notifier" \
                          "Updates available ($progname)" \
-			 "$msg"
+            			  "$msg" "UpdateInTerminal --nt=update")
+        echo "$cmd"
+        bash -c "$cmd" &
     fi
 }
 

--- a/eos-update-notifier/eos-update-notifier
+++ b/eos-update-notifier/eos-update-notifier
@@ -85,10 +85,11 @@ ShowNotify() {
     esac
     if [ 0 -eq 1 ] ; then
         expiretime="--expire-time=$expiretime"
-        /usr/bin/notify-send --icon="$_UpdateNotifyIcon" --urgency=normal $expiretime \
+        cmd=$(/usr/bin/notify-send --icon="$_UpdateNotifyIcon" --urgency=normal $expiretime \
                              --app-name="EndeavourOS Update Notifier" \
                              "Updates available ($progname)" \
-			     "$msg"
+			     "$msg" --action "UpdateInTerminal --nt"=update)
+	bash -c "$cmd"
     else
         eos_notification "$_UpdateNotifyIcon" "normal" "$expiretime" "EndeavourOS Update Notifier" \
                          "Updates available ($progname)" \


### PR DESCRIPTION
I just though it would be more convenient to do an action in dunst than to open a terminal and then type `sudo pacman -Syu` or `yay` or your alias to update EndeavourOS.

I don't know if I should add an action argument for eos_notification or to tell users about it though.