### PR TITLE
Update eos-hooks-runner

### DIFF
--- a/eos-hooks/eos-hooks-runner
+++ b/eos-hooks/eos-hooks-runner
@@ -26,17 +26,17 @@ Os_release() {
     local bugs=https://forum.endeavouros.com/c/arch-based-related-questions/bug-reports
     local privacy=https://endeavouros.com/privacy-policy-2
 
-    sed -i $file \
-        -e 's|^NAME=.*$|NAME=EndeavourOS|' \
-        -e 's|^PRETTY_NAME=.*$|PRETTY_NAME=EndeavourOS|' \
-        -e "s|^HOME_URL=.*$|HOME_URL='$home'|" \
-        -e "s|^DOCUMENTATION_URL=.*$|DOCUMENTATION_URL='$doc'|" \
-        -e "s|^SUPPORT_URL=.*$|SUPPORT_URL='$support'|" \
-        -e "s|^BUG_REPORT_URL=.*$|BUG_REPORT_URL='$bugs'|" \
+sed -i $file \
+        -e "s|^NAME=.*$|NAME=\"EndeavourOS\"|" \
+        -e "s|^PRETTY_NAME=.*$|PRETTY_NAME=\"EndeavourOS\"|" \
+        -e "s|^HOME_URL=.*$|HOME_URL=\"$home\"|" \
+        -e "s|^DOCUMENTATION_URL=.*$|DOCUMENTATION_URL=\"$doc\"|" \
+        -e "s|^SUPPORT_URL=.*$|SUPPORT_URL=\"$support\"|" \
+        -e "s|^BUG_REPORT_URL=.*$|BUG_REPORT_URL=\"$bugs\"|" \
         -e "s|^LOGO=.*$|LOGO=endeavouros|" \
         -e "s|^ID=.*$|ID=endeavouros|" \
         -e "s|^ID_LIKE=.*$|ID_LIKE=arch|" \
-        -e "s|^PRIVACY_POLICY_URL=.*$|PRIVACY_POLICY_URL=$privacy|"
+        -e "s|^PRIVACY_POLICY_URL=.*$|PRIVACY_POLICY_URL=\"$privacy\"|"
 
     if [ -z "$(grep "^ID_LIKE=" $file)" ] && [ -n "$(grep "^ID=" $file)" ] ; then
         # add missing ID_LIKE=


### PR DESCRIPTION
PRIVACY_POLICY_URL (Line 39) had no quoting on url causing cockpit login failures (python errors). A single hash quote on this line of $privacy will correct issue.

Further, to remain consistent with upstream Archlinux, change single hash quotes to double hash quotes, and add missing quotes.