### PR TITLE
Remove hooks that are no longer included from eos-hooks docs

### DIFF
--- a/eos-bash-shared/README.md
+++ b/eos-bash-shared/README.md
@@ -1,0 +1,9 @@
+# eos-bash-shared
+
+Various different terminal and misc improvements to the user experience.
+
+File name | Description
+:--- | :---
+eos-reboot-required | (Obsoleted) Notifies user to reboot after essential system files have been updated.
+eos-reboot-required2 | Filters packages that may need a notificication about a recommended reboot.
+eos-reboot-required.hook | Runs `eos-reboot-required2` after any of the listed essential system packages have been updated.

--- a/eos-hooks/README.md
+++ b/eos-hooks/README.md
@@ -8,6 +8,4 @@ eos-hooks-runner | Fixes files like `os-release`, `lsb-release`, `issues` for En
 eos-hooks.hook | Runs `eos-hooks-runner` after the `eos-hooks` package is updated.
 eos-lsb-release.hook | Runs `eos-hooks-runner` after package `lsb-release` has been updated.
 eos-os-release.hook | Runs `eos-hooks-runner` after package `filesystem` has been updated.
-eos-reboot-required | (Obsoleted) Notifies user to reboot after essential system files have been updated.
-eos-reboot-required2 | Filters packages that may need a notificication about a recommended reboot.
-eos-reboot-required.hook | Runs `eos-reboot-required2` after any of the listed essential system packages have been updated.
+


### PR DESCRIPTION
Also adds readme that includes the hooks that are now included in ``eos-bash-shared``. I have not yet included the other misc files yet.