### PR TITLE
Adding Vietnam's new mirror

### DIFF
--- a/endeavouros-mirrorlist/endeavouros-mirrorlist
+++ b/endeavouros-mirrorlist/endeavouros-mirrorlist
@@ -55,3 +55,6 @@ Server = https://fastmirror.pp.ua/endeavouros/repo/$repo/$arch
 ## United States
 Server = https://mirrors.gigenet.com/endeavouros/repo/$repo/$arch
 
+## Vietnam
+Server = https://mirrors.nguyenhoang.cloud/endeavouros/repo/$repo/$arch
+


### PR DESCRIPTION
This is replacing the old 42tm mirror after months of service interruption.
I also sent Alpix (alpix //AT//endeavouros.com) an email.