### PR TITLE
Fix typo

### DIFF
--- a/eos-apps-info/man/curl-exit-code-to-string/curl-exit-core-to-string.md
+++ b/eos-apps-info/man/curl-exit-code-to-string/curl-exit-core-to-string.md
@@ -1,6 +1,6 @@
 # curl-exit-code-to-string
 
-A toubleshooting helper: this app returns a string describing the given exit code of `curl`.
+A troubleshooting helper: this app returns a string describing the given exit code of `curl`.
 
 The list of strings referred to by the `curl` exit code is updated regularly (currently at least weekly).
 


### PR DESCRIPTION
- [Fixed] Just a tiny typo in the word `toubleshooting`