### PR TITLE
[eos-hooks-runner] replace non existing BUG report URL

### DIFF
--- a/eos-hooks/eos-hooks-runner
+++ b/eos-hooks/eos-hooks-runner
@@ -24,7 +24,7 @@ Os_release() {
     local home=https://endeavouros.com
     local doc=https://discovery.endeavouros.com
     local support=https://forum.endeavouros.com
-    local bugs=https://forum.endeavouros.com/c/arch-based-related-questions/bug-reports
+    local bugs=https://forum.endeavouros.com/c/general-system/endeavouros-installation
     local privacy=https://endeavouros.com/privacy-policy-2
 
     sed -i $file \


### PR DESCRIPTION
Not exactly remembering, what was our conclusion? 
But the non-existing BUG report URL should be removed or, as I did, replace with a fitting one to installation issues.
@manuel-192 