### PR TITLE
[nvidia-inst] handle missing linux kernel headers for dkms

### DIFF
--- a/nvidia-inst/nvidia-inst
+++ b/nvidia-inst/nvidia-inst
@@ -149,6 +149,8 @@ AdjustPkgsAboutDkms() {
                         ;;
                 esac
             done
+	    IsInstalled linux     && adjusted+=(linux-headers)
+            IsInstalled linux-lts && adjusted+=(linux-lts-headers)
             if [ ${#adjusted[@]} -gt 0 ] ; then
                 install=("${adjusted[@]}")
             fi


### PR DESCRIPTION
Accounts for missing `linux` and/or `linux-lts` kernel headers when the dkms driver is to be used.

`nvidia-inst` guides users through the process of installing all that's necessary for a particular nvidia driver.  However, when installing a dkms driver, it only assumes the user has the respective kernel headers installed, and may result in a non-working driver install if they don't.

The added test simply checks if `linux` or `linux-lts` are installed, and adds their respective headers to the `install` array, which is ultimately filtered through the `KeepsAndRemoves` function, removing them from the final install string if they're already installed.

This issue was encountered [here](https://forum.endeavouros.com/t/nvidia-inst-news/69810/28).